### PR TITLE
Auto refine and better expanded map

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1132,6 +1132,12 @@ body {
   flex-direction: column;
 }
 
+.packet-map-card.map-card-expanded {
+  height: calc(100vh - 120px);
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}
+
 .packet-map-card h3 {
   margin: 0 0 1rem 0;
   font-size: 1.1rem;
@@ -1170,6 +1176,15 @@ body {
 .packet-map {
   border-radius: 4px;
   overflow: hidden;
+  position: relative;
+  width: 100%;
+  min-height: 400px;
+  flex: 1;
+}
+
+.map-card-expanded .packet-map {
+  flex: 1;
+  min-height: 0;
 }
 
 /* Tabs container */

--- a/src/components/PacketDetail.tsx
+++ b/src/components/PacketDetail.tsx
@@ -588,14 +588,14 @@ export function PacketDetail({ packetId, nodeLookup, onBack, onNodeClick, onChan
           const mapKey = `map-${packet.id}-${mapExpanded}`;
 
           return (
-            <div className="packet-map-card" ref={mapCardRef}>
+            <div className={`packet-map-card ${mapExpanded ? 'map-card-expanded' : ''}`} ref={mapCardRef}>
               <h3>Gateway Locations</h3>
               <div className="packet-map">
                 <MapContainer
                   key={mapKey}
                   center={[centerLat, centerLng]}
                   zoom={10}
-                  style={{ height: mapExpanded ? '800px' : '400px', width: '100%' }}
+                  style={{ height: '100%', width: '100%' }}
                   closePopupOnClick={false}
                 >
                   <LayersControl position="topright">


### PR DESCRIPTION
This pull request introduces a new "easter egg" feature in the `PacketDetail` component that allows users to automatically refine all ambiguous relay nodes by triple-clicking the Gateways header. It also improves the visual layout of the map card and map display, making the expanded map fill the available space more elegantly.

**Feature Addition:**

* Added an "auto-refine all ambiguous relays" easter egg, triggered by triple-clicking the Gateways header. This feature automatically refines all gateways with ambiguous relay matches, with a visible "Auto-refining..." indicator during the process. [[1]](diffhunk://#diff-d41e2067c57fc804e0fdff6084a3875d9277a4832705c0957d69e48d6daae586R246-R295) [[2]](diffhunk://#diff-d41e2067c57fc804e0fdff6084a3875d9277a4832705c0957d69e48d6daae586L966-R1025)

**UI/UX Improvements:**

* Updated the map card styling in `src/App.css` so that the expanded map card fills the viewport height minus a fixed offset, with improved margin handling.
* Enhanced the `.packet-map` styling to ensure it uses all available space and has a minimum height, both in normal and expanded states.
* Modified the map rendering in `PacketDetail.tsx` so that the map height is always 100% of its container, relying on CSS for sizing instead of inline styles.

**Code Maintenance:**

* Added state and refs to support the triple-click detection and auto-refining logic, ensuring the feature is robust and does not interfere with normal usage.